### PR TITLE
Fix Various Issues With The fileorganizer Dialog

### DIFF
--- a/Emby.AutoOrganize/Configuration/fileorganizer.js
+++ b/Emby.AutoOrganize/Configuration/fileorganizer.js
@@ -392,8 +392,7 @@ define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button',
 
                     dlg.querySelector('.formDialogHeaderTitle').innerHTML = 'Organize';
 
-                    dialogHelper.open(dlg);
-
+                    // Add event listeners to dialog
                     dlg.addEventListener('close', function () {
 
                         if (dlg.submitted) {
@@ -435,7 +434,10 @@ define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button',
 
                     // Init media type
                     selectedMediaTypeChanged(dlg, item);
-                }
+
+                    // Show dialog
+                    dialogHelper.open(dlg);
+                };
 
                 xhr.send();
             });

--- a/Emby.AutoOrganize/Configuration/fileorganizer.js
+++ b/Emby.AutoOrganize/Configuration/fileorganizer.js
@@ -104,10 +104,13 @@ define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button',
         loading.hide();
 
         require(['alert'], function (alert) {
-            alert({
-                title: 'Error',
-                text: 'Error: ' + (e.headers.get("X-Application-Error-Code") || "No message provided.")
-            });
+            // Get message from server or display a default message
+            var message =
+                e.headers.get("X-Application-Error-Code") ||
+                "Server returned status code " + e.status + " (" + e.statusText + ") but did not provide a more specific error message.";
+
+            // Show the error using an alert dialog
+            alert({ title: 'Error', text: 'Error: ' + message });
         });
     }
 

--- a/Emby.AutoOrganize/Configuration/fileorganizer.js
+++ b/Emby.AutoOrganize/Configuration/fileorganizer.js
@@ -284,7 +284,7 @@ define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button',
             require(['alert'], function (alert) {
                 alert({
                     title: 'Error',
-                    text: 'No TV libraries are configured in Emby library setup.'
+                    text: 'No TV libraries are configured in Jellyfin library setup.'
                 });
             });
             return;

--- a/Emby.AutoOrganize/Configuration/fileorganizer.js
+++ b/Emby.AutoOrganize/Configuration/fileorganizer.js
@@ -106,7 +106,7 @@ define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button',
         require(['alert'], function (alert) {
             alert({
                 title: 'Error',
-                text: 'Error: ' + e.headers.get("X-Application-Error-Code")
+                text: 'Error: ' + (e.headers.get("X-Application-Error-Code") || "No message provided.")
             });
         });
     }

--- a/Emby.AutoOrganize/Configuration/fileorganizer.js
+++ b/Emby.AutoOrganize/Configuration/fileorganizer.js
@@ -1,4 +1,4 @@
-﻿define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button', 'emby-select', 'paper-icon-button-light', 'formDialogStyle'], function (dialogHelper, loading) {
+define(['dialogHelper', 'loading', 'emby-checkbox', 'emby-input', 'emby-button', 'emby-select', 'paper-icon-button-light', 'formDialogStyle'], function (dialogHelper, loading) {
     'use strict';
 
     ApiClient.getFileOrganizationResults = function (options) {
@@ -319,7 +319,9 @@
     }
 
     function selectedMediaTypeChanged(dlg, item) {
+
         var mediaType = dlg.querySelector('#selectMediaType').value;
+        var mediaSelector = dlg.querySelector('#selectMedias');
 
         switch (mediaType) {
             case "":
@@ -328,8 +330,8 @@
                 dlg.querySelector('#divEpisodeChoice').classList.add('hide');
                 break;
             case "Movie":
-                dlg.querySelector('#selectMedias').setAttribute('label', 'Movie');
-                dlg.querySelector('[for="selectMedias"]').innerHTML =  'Movie';
+                mediaSelector.setAttribute('label', 'Movie');
+                if (mediaSelector && mediaSelector.setLabel) mediaSelector.setLabel('Movie');
 
                 dlg.querySelector('#divPermitChoice').classList.remove('hide');
                 dlg.querySelector('#divGlobalChoice').classList.remove('hide');
@@ -342,8 +344,8 @@
 
                 break;
             case "Episode":
-                dlg.querySelector('#selectMedias').setAttribute('label', 'Series');
-                dlg.querySelector('[for="selectMedias"]').innerHTML = 'Series';
+                mediaSelector.setAttribute('label', 'Series');
+                if (mediaSelector && mediaSelector.setLabel) mediaSelector.setLabel('Series');
 
                 dlg.querySelector('#divPermitChoice').classList.remove('hide');
                 dlg.querySelector('#divGlobalChoice').classList.remove('hide');


### PR DESCRIPTION
This PR addresses several issues with the fileorganizer dialog:
- [x] Initialize label for media selector correctly
- [x] Replace 'Emby' with 'Jellyfin' in error message
- [x] Display a default error message if none is provided by the server
- [x] Open the fileorganizer dialog only after it has been fully initialized
- [x] Add more detail to unhanded server errors

**NOTE: The version number for the plugin has not been updated here.** I'm not sure how releases are performed and how changes should be coordinated with the existing PR #17 