### PR TITLE
Integrate FxCop Analyzer

### DIFF
--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -5,7 +5,6 @@ using Emby.AutoOrganize.Model;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Querying;
-using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Services;
 
 namespace Emby.AutoOrganize.Api

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -81,7 +81,6 @@ namespace Emby.AutoOrganize.Api
         [ApiMember(Name = "RememberCorrection", Description = "Whether or not to apply the same correction to future episodes of the same series.", IsRequired = false, DataType = "bool", ParameterType = "query", Verb = "POST")]
         public bool RememberCorrection { get; set; }
 
-        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "NewSeriesProviderIds", Description = "A list of provider IDs identifying a new series.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
         public Dictionary<string, string> NewSeriesProviderIds { get; set; }
 
@@ -104,7 +103,6 @@ namespace Emby.AutoOrganize.Api
         [ApiMember(Name = "MovieId", Description = "Movie Id", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string MovieId { get; set; }
 
-        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "NewMovieProviderIds", Description = "A list of provider IDs identifying a new movie.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
         public Dictionary<string, string> NewMovieProviderIds { get; set; }
 
@@ -139,7 +137,6 @@ namespace Emby.AutoOrganize.Api
     [Route("/Library/FileOrganizations/SmartMatches/Delete", "POST", Summary = "Deletes a smart match entry")]
     public class DeleteSmartMatchEntry
     {
-        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "Entries", Description = "SmartMatch Entry", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
         public List<NameValuePair> Entries { get; set; }
     }
@@ -179,7 +176,7 @@ namespace Emby.AutoOrganize.Api
             Task.WaitAll(task);
         }
 
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to defined API route.")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to define an API route.")]
         public void Delete(ClearOrganizationLog request)
         {
             var task = InternalFileOrganizationService.ClearLog();
@@ -187,7 +184,7 @@ namespace Emby.AutoOrganize.Api
             Task.WaitAll(task);
         }
 
-        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to defined API route.")]
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to define an API route.")]
         public void Delete(ClearOrganizationCompletedLog request)
         {
             var task = InternalFileOrganizationService.ClearCompleted();

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -82,6 +82,7 @@ namespace Emby.AutoOrganize.Api
         public bool RememberCorrection { get; set; }
 
         [ApiMember(Name = "NewSeriesProviderIds", Description = "A list of provider IDs identifying a new series.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "ServiceStack cannot deserialize readonly dictionaries.")]
         public Dictionary<string, string> NewSeriesProviderIds { get; set; }
 
         [ApiMember(Name = "NewSeriesName", Description = "Name of a series to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
@@ -104,6 +105,7 @@ namespace Emby.AutoOrganize.Api
         public string MovieId { get; set; }
 
         [ApiMember(Name = "NewMovieProviderIds", Description = "A list of provider IDs identifying a new movie.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "ServiceStack cannot deserialize readonly dictionaries.")]
         public Dictionary<string, string> NewMovieProviderIds { get; set; }
 
         [ApiMember(Name = "NewMovieName", Description = "Name of a movie to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
@@ -138,7 +140,7 @@ namespace Emby.AutoOrganize.Api
     public class DeleteSmartMatchEntry
     {
         [ApiMember(Name = "Entries", Description = "SmartMatch Entry", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
-        public List<NameValuePair> Entries { get; set; }
+        public IReadOnlyList<NameValuePair> Entries { get; set; }
     }
 
     [Authenticated(Roles = "Admin")]
@@ -205,13 +207,6 @@ namespace Emby.AutoOrganize.Api
 
         public void Post(OrganizeEpisode request)
         {
-            var dicNewProviderIds = new Dictionary<string, string>();
-
-            if (request.NewSeriesProviderIds != null)
-            {
-                dicNewProviderIds = request.NewSeriesProviderIds;
-            }
-
             // Don't await this
             var task = InternalFileOrganizationService.PerformOrganization(new EpisodeFileOrganizationRequest
             {
@@ -223,7 +218,7 @@ namespace Emby.AutoOrganize.Api
                 SeriesId = request.SeriesId,
                 NewSeriesName = request.NewSeriesName,
                 NewSeriesYear = request.NewSeriesYear,
-                NewSeriesProviderIds = dicNewProviderIds,
+                NewSeriesProviderIds = request.NewSeriesProviderIds ?? new Dictionary<string, string>(),
                 TargetFolder = request.TargetFolder
             });
 
@@ -234,13 +229,6 @@ namespace Emby.AutoOrganize.Api
 
         public void Post(OrganizeMovie request)
         {
-            var dicNewProviderIds = new Dictionary<string, string>();
-
-            if (request.NewMovieProviderIds != null)
-            {
-                dicNewProviderIds = request.NewMovieProviderIds;
-            }
-
             // Don't await this
             var task = InternalFileOrganizationService.PerformOrganization(new MovieFileOrganizationRequest
             {
@@ -248,7 +236,7 @@ namespace Emby.AutoOrganize.Api
                 MovieId = request.MovieId,
                 NewMovieName = request.NewMovieName,
                 NewMovieYear = request.NewMovieYear,
-                NewMovieProviderIds = dicNewProviderIds,
+                NewMovieProviderIds = request.NewMovieProviderIds ?? new Dictionary<string, string>(),
                 TargetFolder = request.TargetFolder
             });
 

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -216,7 +216,7 @@ namespace Emby.AutoOrganize.Api
             }
 
             // Don't await this
-            var task = InternalFileOrganizationService.PerformOrganization(new EpisodeFileOrganizationRequest(dicNewProviderIds)
+            var task = InternalFileOrganizationService.PerformOrganization(new EpisodeFileOrganizationRequest
             {
                 EndingEpisodeNumber = request.EndingEpisodeNumber,
                 EpisodeNumber = request.EpisodeNumber,
@@ -226,6 +226,7 @@ namespace Emby.AutoOrganize.Api
                 SeriesId = request.SeriesId,
                 NewSeriesName = request.NewSeriesName,
                 NewSeriesYear = request.NewSeriesYear,
+                NewSeriesProviderIds = dicNewProviderIds,
                 TargetFolder = request.TargetFolder
             });
 
@@ -244,12 +245,13 @@ namespace Emby.AutoOrganize.Api
             }
 
             // Don't await this
-            var task = InternalFileOrganizationService.PerformOrganization(new MovieFileOrganizationRequest(dicNewProviderIds)
+            var task = InternalFileOrganizationService.PerformOrganization(new MovieFileOrganizationRequest
             {
                 ResultId = request.Id,
                 MovieId = request.MovieId,
                 NewMovieName = request.NewMovieName,
                 NewMovieYear = request.NewMovieYear,
+                NewMovieProviderIds = dicNewProviderIds,
                 TargetFolder = request.TargetFolder
             });
 

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -81,8 +81,9 @@ namespace Emby.AutoOrganize.Api
         [ApiMember(Name = "RememberCorrection", Description = "Whether or not to apply the same correction to future episodes of the same series.", IsRequired = false, DataType = "bool", ParameterType = "query", Verb = "POST")]
         public bool RememberCorrection { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "NewSeriesProviderIds", Description = "A list of provider IDs identifying a new series.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
-        public Dictionary<string, string> NewSeriesProviderIds { get; }
+        public Dictionary<string, string> NewSeriesProviderIds { get; set; }
 
         [ApiMember(Name = "NewSeriesName", Description = "Name of a series to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string NewSeriesName { get; set; }
@@ -103,8 +104,9 @@ namespace Emby.AutoOrganize.Api
         [ApiMember(Name = "MovieId", Description = "Movie Id", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string MovieId { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "NewMovieProviderIds", Description = "A list of provider IDs identifying a new movie.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
-        public Dictionary<string, string> NewMovieProviderIds { get; }
+        public Dictionary<string, string> NewMovieProviderIds { get; set; }
 
         [ApiMember(Name = "NewMovieName", Description = "Name of a movie to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string NewMovieName { get; set; }
@@ -137,8 +139,9 @@ namespace Emby.AutoOrganize.Api
     [Route("/Library/FileOrganizations/SmartMatches/Delete", "POST", Summary = "Deletes a smart match entry")]
     public class DeleteSmartMatchEntry
     {
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "API request collections must be writable")]
         [ApiMember(Name = "Entries", Description = "SmartMatch Entry", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
-        public List<NameValuePair> Entries { get; } = new List<NameValuePair>();
+        public List<NameValuePair> Entries { get; set; }
     }
 
     [Authenticated(Roles = "Admin")]

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Emby.AutoOrganize.Core;
 using Emby.AutoOrganize.Model;
@@ -175,6 +176,7 @@ namespace Emby.AutoOrganize.Api
             Task.WaitAll(task);
         }
 
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to defined API route.")]
         public void Delete(ClearOrganizationLog request)
         {
             var task = InternalFileOrganizationService.ClearLog();
@@ -182,7 +184,7 @@ namespace Emby.AutoOrganize.Api
             Task.WaitAll(task);
         }
 
-
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Parameter is used to defined API route.")]
         public void Delete(ClearOrganizationCompletedLog request)
         {
             var task = InternalFileOrganizationService.ClearCompleted();

--- a/Emby.AutoOrganize/Api/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Api/FileOrganizationService.cs
@@ -82,7 +82,7 @@ namespace Emby.AutoOrganize.Api
         public bool RememberCorrection { get; set; }
 
         [ApiMember(Name = "NewSeriesProviderIds", Description = "A list of provider IDs identifying a new series.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
-        public Dictionary<string, string> NewSeriesProviderIds { get; set; }
+        public Dictionary<string, string> NewSeriesProviderIds { get; }
 
         [ApiMember(Name = "NewSeriesName", Description = "Name of a series to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string NewSeriesName { get; set; }
@@ -104,7 +104,7 @@ namespace Emby.AutoOrganize.Api
         public string MovieId { get; set; }
 
         [ApiMember(Name = "NewMovieProviderIds", Description = "A list of provider IDs identifying a new movie.", IsRequired = false, DataType = "Dictionary<string, string>", ParameterType = "query", Verb = "POST")]
-        public Dictionary<string, string> NewMovieProviderIds { get; set; }
+        public Dictionary<string, string> NewMovieProviderIds { get; }
 
         [ApiMember(Name = "NewMovieName", Description = "Name of a movie to add.", IsRequired = false, DataType = "string", ParameterType = "query", Verb = "POST")]
         public string NewMovieName { get; set; }
@@ -138,7 +138,7 @@ namespace Emby.AutoOrganize.Api
     public class DeleteSmartMatchEntry
     {
         [ApiMember(Name = "Entries", Description = "SmartMatch Entry", IsRequired = true, DataType = "string", ParameterType = "query", Verb = "POST")]
-        public List<NameValuePair> Entries { get; set; }
+        public List<NameValuePair> Entries { get; } = new List<NameValuePair>();
     }
 
     [Authenticated(Roles = "Admin")]
@@ -213,7 +213,7 @@ namespace Emby.AutoOrganize.Api
             }
 
             // Don't await this
-            var task = InternalFileOrganizationService.PerformOrganization(new EpisodeFileOrganizationRequest
+            var task = InternalFileOrganizationService.PerformOrganization(new EpisodeFileOrganizationRequest(dicNewProviderIds)
             {
                 EndingEpisodeNumber = request.EndingEpisodeNumber,
                 EpisodeNumber = request.EpisodeNumber,
@@ -223,7 +223,6 @@ namespace Emby.AutoOrganize.Api
                 SeriesId = request.SeriesId,
                 NewSeriesName = request.NewSeriesName,
                 NewSeriesYear = request.NewSeriesYear,
-                NewSeriesProviderIds = dicNewProviderIds,
                 TargetFolder = request.TargetFolder
             });
 
@@ -242,13 +241,12 @@ namespace Emby.AutoOrganize.Api
             }
 
             // Don't await this
-            var task = InternalFileOrganizationService.PerformOrganization(new MovieFileOrganizationRequest
+            var task = InternalFileOrganizationService.PerformOrganization(new MovieFileOrganizationRequest(dicNewProviderIds)
             {
                 ResultId = request.Id,
                 MovieId = request.MovieId,
                 NewMovieName = request.NewMovieName,
                 NewMovieYear = request.NewMovieYear,
-                NewMovieProviderIds = dicNewProviderIds,
                 TargetFolder = request.TargetFolder
             });
 

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -167,7 +167,7 @@ namespace Emby.AutoOrganize.Core
                     }
                     else
                     {
-                        var msg = string.Format("Unable to determine episode number from {0}", path);
+                        var msg = "Unable to determine episode number from " + path;
                         result.Status = FileSortingStatus.Failure;
                         result.StatusMessage = msg;
                         _logger.LogWarning(msg);
@@ -175,7 +175,7 @@ namespace Emby.AutoOrganize.Core
                 }
                 else
                 {
-                    var msg = string.Format("Unable to determine series name from {0}", path);
+                    var msg = "Unable to determine series name from {0}" + path;
                     result.Status = FileSortingStatus.Failure;
                     result.StatusMessage = msg;
                     _logger.LogWarning(msg);
@@ -388,7 +388,7 @@ namespace Emby.AutoOrganize.Core
 
                 if (series == null)
                 {
-                    var msg = string.Format("Unable to find series in library matching name {0}", seriesName);
+                    var msg = "Unable to find series in library matching name " + seriesName;
                     result.Status = FileSortingStatus.Failure;
                     result.StatusMessage = msg;
                     _logger.LogWarning(msg);
@@ -487,7 +487,7 @@ namespace Emby.AutoOrganize.Core
 
                 if (string.IsNullOrEmpty(newPath))
                 {
-                    var msg = string.Format("Unable to sort {0} because target path could not be determined.", sourcePath);
+                    var msg = $"Unable to sort {sourcePath} because target path could not be determined.";
                     throw new OrganizationException(msg);
                 }
 
@@ -501,7 +501,7 @@ namespace Emby.AutoOrganize.Core
                 {
                     if (options.CopyOriginalFile && fileExists && IsSameEpisode(sourcePath, newPath))
                     {
-                        var msg = string.Format("File '{0}' already copied to new path '{1}', stopping organization", sourcePath, newPath);
+                        var msg = $"File '{sourcePath}' already copied to new path '{newPath}', stopping organization";
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
@@ -510,7 +510,7 @@ namespace Emby.AutoOrganize.Core
 
                     if (fileExists)
                     {
-                        var msg = string.Format("File '{0}' already exists as '{1}', stopping organization", sourcePath, newPath);
+                        var msg = $"File '{sourcePath}' already exists as '{newPath}', stopping organization";
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
@@ -520,7 +520,7 @@ namespace Emby.AutoOrganize.Core
 
                     if (otherDuplicatePaths.Count > 0)
                     {
-                        var msg = string.Format("File '{0}' already exists as these:'{1}'. Stopping organization", sourcePath, string.Join("', '", otherDuplicatePaths));
+                        var msg = $"File '{sourcePath}' already exists as these:'{string.Join("', '", otherDuplicatePaths)}'. Stopping organization";
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
@@ -734,7 +734,7 @@ namespace Emby.AutoOrganize.Core
             }
             catch (Exception ex)
             {
-                var errorMsg = string.Format("Failed to move file from {0} to {1}: {2}", result.OriginalPath, result.TargetPath, ex.Message);
+                var errorMsg = $"Failed to move file from {result.OriginalPath} to {result.TargetPath}: {ex.Message}";
 
                 result.Status = FileSortingStatus.Failure;
                 result.StatusMessage = errorMsg;
@@ -799,8 +799,7 @@ namespace Emby.AutoOrganize.Core
                 {
                     if (!episode.ParentIndexNumber.HasValue)
                     {
-                        var msg = string.Format("No season found for {0} season {1} episode {2}", series.Name,
-                            episode.ParentIndexNumber, episode.IndexNumber);
+                        var msg = $"No season found for {series.Name} season {episode.ParentIndexNumber} episode {episode.IndexNumber}.";
                         _logger.LogWarning(msg);
                         throw new OrganizationException(msg);
                     }
@@ -843,7 +842,7 @@ namespace Emby.AutoOrganize.Core
                 .Where(i => i.Item2 > 0)
                 .OrderByDescending(i => i.Item2)
                 .Select(i => i.Item1)
-                .FirstOrDefault(s => s.Path.StartsWith(targetFolder));
+                .FirstOrDefault(s => s.Path.StartsWith(targetFolder, StringComparison.Ordinal));
 
             if (series == null)
             {
@@ -858,7 +857,7 @@ namespace Emby.AutoOrganize.Core
                         Name = info.ItemName,
                         DtoOptions = new DtoOptions(true)
 
-                    }).Cast<Series>().FirstOrDefault(s => s.Path.StartsWith(targetFolder));
+                    }).Cast<Series>().FirstOrDefault(s => s.Path.StartsWith(targetFolder, StringComparison.Ordinal));
                 }
             }
 
@@ -878,7 +877,7 @@ namespace Emby.AutoOrganize.Core
             var seriesFullName = seriesName;
             if (series.ProductionYear.HasValue)
             {
-                seriesFullName = string.Format("{0} ({1})", seriesFullName, series.ProductionYear);
+                seriesFullName = $"{seriesFullName} ({series.ProductionYear})";
             }
 
             var seasonFolderName = options.SeriesFolderPattern.
@@ -930,7 +929,7 @@ namespace Emby.AutoOrganize.Core
 
             if (episodeSearch == null)
             {
-                var msg = string.Format("No provider metadata found for {0} season {1} episode {2}", series.Name, seasonNumber, episodeNumber);
+                var msg = $"No provider metadata found for {series.Name} season {seasonNumber} episode {episodeNumber}";
                 _logger.LogWarning(msg);
                 throw new OrganizationException(msg);
             }

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -434,8 +434,7 @@ namespace Emby.AutoOrganize.Core
                 endingEpiosdeNumber,
                 result,
                 premiereDate,
-                cancellationToken
-            ).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             Season season;
             season = !string.IsNullOrEmpty(episode.Season?.Path)
@@ -455,8 +454,7 @@ namespace Emby.AutoOrganize.Core
                 options,
                 rememberCorrection,
                 result,
-                cancellationToken
-            ).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private Task OrganizeEpisode(string sourcePath,

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -457,7 +457,8 @@ namespace Emby.AutoOrganize.Core
                 cancellationToken).ConfigureAwait(false);
         }
 
-        private Task OrganizeEpisode(string sourcePath,
+        private Task OrganizeEpisode(
+            string sourcePath,
             Series series,
             Episode episode,
             TvFileOrganizationOptions options,

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -459,7 +459,7 @@ namespace Emby.AutoOrganize.Core
             ).ConfigureAwait(false);
         }
 
-        private async Task OrganizeEpisode(string sourcePath,
+        private Task OrganizeEpisode(string sourcePath,
             Series series,
             Episode episode,
             TvFileOrganizationOptions options,
@@ -508,7 +508,7 @@ namespace Emby.AutoOrganize.Core
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     if (fileExists)
@@ -518,7 +518,7 @@ namespace Emby.AutoOrganize.Core
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
                         result.TargetPath = newPath;
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     if (otherDuplicatePaths.Count > 0)
@@ -528,7 +528,7 @@ namespace Emby.AutoOrganize.Core
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
                         result.DuplicatePaths = otherDuplicatePaths;
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
 
@@ -572,7 +572,7 @@ namespace Emby.AutoOrganize.Core
                 result.Status = FileSortingStatus.Failure;
                 result.StatusMessage = ex.Message;
                 _logger.LogError(ex, "Caught a generic exception while organizing an episode");
-                return;
+                return Task.CompletedTask;
             }
             finally
             {
@@ -583,6 +583,8 @@ namespace Emby.AutoOrganize.Core
             {
                 SaveSmartMatchString(originalExtractedSeriesString, series, cancellationToken);
             }
+
+            return Task.CompletedTask;
         }
 
         private void SaveSmartMatchString(string matchString, Series series, CancellationToken cancellationToken)

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -301,7 +301,7 @@ namespace Emby.AutoOrganize.Core
                     // Create the folder
                     Directory.CreateDirectory(series.Path);
 
-                    series.ProviderIds = request.NewSeriesProviderIds;
+                    series.ProviderIds = request.NewSeriesProviderIds.ToDictionary(x => x.Key, x => x.Value);
                 }
             }
 

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -30,14 +30,12 @@ namespace Emby.AutoOrganize.Core
         private readonly ILogger _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
-        private readonly IServerConfigurationManager _config;
         private readonly IProviderManager _providerManager;
 
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
 
         public EpisodeFileOrganizer(
             IFileOrganizationService organizationService,
-            IServerConfigurationManager config,
             IFileSystem fileSystem,
             ILogger logger,
             ILibraryManager libraryManager,
@@ -45,7 +43,6 @@ namespace Emby.AutoOrganize.Core
             IProviderManager providerManager)
         {
             _organizationService = organizationService;
-            _config = config;
             _fileSystem = fileSystem;
             _logger = logger;
             _libraryManager = libraryManager;
@@ -415,7 +412,6 @@ namespace Emby.AutoOrganize.Core
         /// <param name="endingEpiosdeNumber"></param>
         /// <param name="premiereDate"></param>
         /// <param name="options"></param>
-        /// <param name="smartMatch"></param>
         /// <param name="rememberCorrection"></param>
         /// <param name="result"></param>
         /// <param name="cancellationToken"></param>

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -253,10 +253,9 @@ namespace Emby.AutoOrganize.Core
                 if (finalResult != null)
                 {
                     // We are in the good position, we can create the item
-                    var organizationRequest = new EpisodeFileOrganizationRequest
+                    var organizationRequest = new EpisodeFileOrganizationRequest(finalResult.ProviderIds)
                     {
                         NewSeriesName = finalResult.Name,
-                        NewSeriesProviderIds = finalResult.ProviderIds,
                         NewSeriesYear = finalResult.ProductionYear,
                         TargetFolder = options.DefaultSeriesLibraryPath
                     };
@@ -527,7 +526,8 @@ namespace Emby.AutoOrganize.Core
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
-                        result.DuplicatePaths = otherDuplicatePaths;
+                        result.DuplicatePaths.Clear();
+                        result.DuplicatePaths.AddRange(otherDuplicatePaths);
                         return Task.CompletedTask;
                     }
                 }

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -228,16 +228,13 @@ namespace Emby.AutoOrganize.Core
                     Year = seriesYear
                 };
 
-                var searchResultsTask = await _providerManager.GetRemoteSearchResults<Series, SeriesInfo>(new RemoteSearchQuery<SeriesInfo>
-                {
-                    SearchInfo = seriesInfo
-
-                }, cancellationToken);
+                var searchQuery = new RemoteSearchQuery<SeriesInfo> { SearchInfo = seriesInfo };
+                var searchResults = await _providerManager.GetRemoteSearchResults<Series, SeriesInfo>(searchQuery, cancellationToken).ConfigureAwait(false);
 
                 #endregion
 
                 // Group series by name and year (if 2 series with the exact same name, the same year ...)
-                var groupedResult = searchResultsTask.GroupBy(p => new { p.Name, p.ProductionYear },
+                var groupedResult = searchResults.GroupBy(p => new { p.Name, p.ProductionYear },
                     p => p,
                     (key, g) => new { Key = key, Result = g.ToList() }).ToList();
 
@@ -434,7 +431,15 @@ namespace Emby.AutoOrganize.Core
             FileOrganizationResult result,
             CancellationToken cancellationToken)
         {
-            var episode = await GetMatchingEpisode(series, seasonNumber, episodeNumber, endingEpiosdeNumber, result, premiereDate, cancellationToken);
+            var episode = await GetMatchingEpisode(
+                series,
+                seasonNumber,
+                episodeNumber,
+                endingEpiosdeNumber,
+                result,
+                premiereDate,
+                cancellationToken
+            ).ConfigureAwait(false);
 
             Season season;
             season = !string.IsNullOrEmpty(episode.Season?.Path)
@@ -447,13 +452,15 @@ namespace Emby.AutoOrganize.Core
                 SetEpisodeFileName(sourcePath, series, season, episode, options);
             }
 
-            await OrganizeEpisode(sourcePath,
+            await OrganizeEpisode(
+                sourcePath,
                 series,
                 episode,
                 options,
                 rememberCorrection,
                 result,
-                cancellationToken);
+                cancellationToken
+            ).ConfigureAwait(false);
         }
 
         private async Task OrganizeEpisode(string sourcePath,

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -253,9 +253,10 @@ namespace Emby.AutoOrganize.Core
                 if (finalResult != null)
                 {
                     // We are in the good position, we can create the item
-                    var organizationRequest = new EpisodeFileOrganizationRequest(finalResult.ProviderIds)
+                    var organizationRequest = new EpisodeFileOrganizationRequest
                     {
                         NewSeriesName = finalResult.Name,
+                        NewSeriesProviderIds = finalResult.ProviderIds,
                         NewSeriesYear = finalResult.ProductionYear,
                         TargetFolder = options.DefaultSeriesLibraryPath
                     };
@@ -526,8 +527,7 @@ namespace Emby.AutoOrganize.Core
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
-                        result.DuplicatePaths.Clear();
-                        result.DuplicatePaths.AddRange(otherDuplicatePaths);
+                        result.DuplicatePaths = otherDuplicatePaths;
                         return Task.CompletedTask;
                     }
                 }

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -172,7 +172,7 @@ namespace Emby.AutoOrganize.Core
                 }
                 else
                 {
-                    var msg = "Unable to determine series name from {0}" + path;
+                    var msg = "Unable to determine series name from " + path;
                     result.Status = FileSortingStatus.Failure;
                     result.StatusMessage = msg;
                     _logger.LogWarning(msg);

--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -440,7 +440,7 @@ namespace Emby.AutoOrganize.Core
             Season season;
             season = !string.IsNullOrEmpty(episode.Season?.Path)
                 ? episode.Season
-                : GetMatchingSeason(series, episode, options, cancellationToken);
+                : GetMatchingSeason(series, episode, options);
 
             // Now we can check the episode Path
             if (string.IsNullOrEmpty(episode.Path))
@@ -789,7 +789,7 @@ namespace Emby.AutoOrganize.Core
             return episode;
         }
 
-        private Season GetMatchingSeason(Series series, Episode episode, TvFileOrganizationOptions options, CancellationToken cancellationToken)
+        private Season GetMatchingSeason(Series series, Episode episode, TvFileOrganizationOptions options)
         {
             var season = episode.Season;
 

--- a/Emby.AutoOrganize/Core/Extensions.cs
+++ b/Emby.AutoOrganize/Core/Extensions.cs
@@ -19,13 +19,14 @@ namespace Emby.AutoOrganize.Core
 
                 foreach (SmartMatchInfo optionsSmartMatchInfo in options.SmartMatchInfos)
                 {
-                    service.SaveResult(new SmartMatchResult
+                    var result = new SmartMatchResult
                     {
                         DisplayName = optionsSmartMatchInfo.DisplayName,
                         ItemName = optionsSmartMatchInfo.ItemName,
                         OrganizerType = optionsSmartMatchInfo.OrganizerType,
-                        MatchStrings = optionsSmartMatchInfo.MatchStrings.ToList(),
-                    }, CancellationToken.None);
+                    };
+                    result.MatchStrings.AddRange(optionsSmartMatchInfo.MatchStrings);
+                    service.SaveResult(result, CancellationToken.None);
                 }
 
                 manager.SaveAutoOrganizeOptions(options);

--- a/Emby.AutoOrganize/Core/Extensions.cs
+++ b/Emby.AutoOrganize/Core/Extensions.cs
@@ -19,13 +19,14 @@ namespace Emby.AutoOrganize.Core
 
                 foreach (SmartMatchInfo optionsSmartMatchInfo in options.SmartMatchInfos)
                 {
-                    service.SaveResult(new SmartMatchResult
+                    var result = new SmartMatchResult
                     {
                         DisplayName = optionsSmartMatchInfo.DisplayName,
                         ItemName = optionsSmartMatchInfo.ItemName,
-                        OrganizerType = optionsSmartMatchInfo.OrganizerType,
-                        MatchStrings = optionsSmartMatchInfo.MatchStrings.ToList(),
-                    }, CancellationToken.None);
+                        OrganizerType = optionsSmartMatchInfo.OrganizerType
+                    };
+                    result.MatchStrings.AddRange(optionsSmartMatchInfo.MatchStrings);
+                    service.SaveResult(result, CancellationToken.None);
                 }
 
                 manager.SaveAutoOrganizeOptions(options);

--- a/Emby.AutoOrganize/Core/Extensions.cs
+++ b/Emby.AutoOrganize/Core/Extensions.cs
@@ -19,14 +19,13 @@ namespace Emby.AutoOrganize.Core
 
                 foreach (SmartMatchInfo optionsSmartMatchInfo in options.SmartMatchInfos)
                 {
-                    var result = new SmartMatchResult
+                    service.SaveResult(new SmartMatchResult
                     {
                         DisplayName = optionsSmartMatchInfo.DisplayName,
                         ItemName = optionsSmartMatchInfo.ItemName,
-                        OrganizerType = optionsSmartMatchInfo.OrganizerType
-                    };
-                    result.MatchStrings.AddRange(optionsSmartMatchInfo.MatchStrings);
-                    service.SaveResult(result, CancellationToken.None);
+                        OrganizerType = optionsSmartMatchInfo.OrganizerType,
+                        MatchStrings = optionsSmartMatchInfo.MatchStrings.ToList(),
+                    }, CancellationToken.None);
                 }
 
                 manager.SaveAutoOrganizeOptions(options);

--- a/Emby.AutoOrganize/Core/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Core/FileOrganizationService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,10 +66,10 @@ namespace Emby.AutoOrganize.Core
         {
             if (result == null || string.IsNullOrEmpty(result.OriginalPath))
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
-            result.Id = result.OriginalPath.GetMD5().ToString("N");
+            result.Id = result.OriginalPath.GetMD5().ToString("N", CultureInfo.InvariantCulture);
 
             _repo.SaveResult(result, cancellationToken);
         }
@@ -77,7 +78,7 @@ namespace Emby.AutoOrganize.Core
         {
             if (result == null)
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
             _repo.SaveResult(result, cancellationToken);
@@ -111,10 +112,10 @@ namespace Emby.AutoOrganize.Core
         {
             if (string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException("path");
+                throw new ArgumentNullException(nameof(path));
             }
 
-            var id = path.GetMD5().ToString("N");
+            var id = path.GetMD5().ToString("N", CultureInfo.InvariantCulture);
 
             return GetResult(id);
         }
@@ -177,8 +178,7 @@ namespace Emby.AutoOrganize.Core
 
                     break;
                 case FileOrganizerType.Movie:
-                    var movieOrganizer = new MovieFileOrganizer(this, _config, _fileSystem, _logger, _libraryManager,
-                        _libraryMonitor, _providerManager);
+                    var movieOrganizer = new MovieFileOrganizer(this, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
 
                     organizeResult = await movieOrganizer.OrganizeMovieFile(result.OriginalPath, options.MovieOptions, true, CancellationToken.None)
                         .ConfigureAwait(false);
@@ -221,8 +221,7 @@ namespace Emby.AutoOrganize.Core
 
         public async Task PerformOrganization(MovieFileOrganizationRequest request)
         {
-            var organizer = new MovieFileOrganizer(this, _config, _fileSystem, _logger, _libraryManager,
-                _libraryMonitor, _providerManager);
+            var organizer = new MovieFileOrganizer(this, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
 
             var options = GetAutoOrganizeOptions();
             var result = await organizer.OrganizeWithCorrection(request, options.MovieOptions, CancellationToken.None).ConfigureAwait(false);

--- a/Emby.AutoOrganize/Core/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Core/FileOrganizationService.cs
@@ -142,7 +142,7 @@ namespace Emby.AutoOrganize.Core
                 RemoveFromInprogressList(result);
             }
 
-            await _repo.Delete(resultId);
+            await _repo.Delete(resultId).ConfigureAwait(false);
 
             ItemRemoved?.Invoke(this, new GenericEventArgs<FileOrganizationResult>(result));
         }
@@ -193,13 +193,13 @@ namespace Emby.AutoOrganize.Core
 
         public async Task ClearLog()
         {
-            await _repo.DeleteAll();
+            await _repo.DeleteAll().ConfigureAwait(false);
             LogReset?.Invoke(this, EventArgs.Empty);
         }
 
         public async Task ClearCompleted()
         {
-            await _repo.DeleteCompleted();
+            await _repo.DeleteCompleted().ConfigureAwait(false);
             LogReset?.Invoke(this, EventArgs.Empty);
         }
 

--- a/Emby.AutoOrganize/Core/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Core/FileOrganizationService.cs
@@ -167,17 +167,12 @@ namespace Emby.AutoOrganize.Core
             switch (result.Type)
             {
                 case FileOrganizerType.Episode:
-                    var episodeOrganizer = new EpisodeFileOrganizer(
-                        this, _config, _fileSystem, _logger, _libraryManager,
-                        _libraryMonitor, _providerManager);
-
+                    var episodeOrganizer = new EpisodeFileOrganizer(this, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
                     organizeResult = await episodeOrganizer.OrganizeEpisodeFile(result.OriginalPath, options.TvOptions, CancellationToken.None)
                         .ConfigureAwait(false);
-
                     break;
                 case FileOrganizerType.Movie:
                     var movieOrganizer = new MovieFileOrganizer(this, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
-
                     organizeResult = await movieOrganizer.OrganizeMovieFile(result.OriginalPath, options.MovieOptions, true, CancellationToken.None)
                         .ConfigureAwait(false);
                     break;
@@ -205,8 +200,7 @@ namespace Emby.AutoOrganize.Core
 
         public async Task PerformOrganization(EpisodeFileOrganizationRequest request)
         {
-            var organizer = new EpisodeFileOrganizer(this, _config, _fileSystem, _logger, _libraryManager,
-                _libraryMonitor, _providerManager);
+            var organizer = new EpisodeFileOrganizer(this, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
 
             var options = GetAutoOrganizeOptions();
             var result = await organizer.OrganizeWithCorrection(request, options.TvOptions, CancellationToken.None).ConfigureAwait(false);

--- a/Emby.AutoOrganize/Core/FileOrganizationService.cs
+++ b/Emby.AutoOrganize/Core/FileOrganizationService.cs
@@ -6,11 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Emby.AutoOrganize.Data;
 using Emby.AutoOrganize.Model;
-using MediaBrowser.Common.Events;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Events;
 using MediaBrowser.Model.IO;
@@ -268,7 +266,7 @@ namespace Emby.AutoOrganize.Core
         {
             if (string.IsNullOrWhiteSpace(result.Id))
             {
-                result.Id = result.OriginalPath.GetMD5().ToString("N");
+                result.Id = result.OriginalPath.GetMD5().ToString("N", CultureInfo.InvariantCulture);
             }
 
             if (!_inProgressItemIds.TryAdd(result.Id, false))

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -154,7 +154,7 @@ namespace Emby.AutoOrganize.Core
                     Name = request.NewMovieName,
                     ProductionYear = request.NewMovieYear,
                     IsInMixedFolder = !options.MovieFolder,
-                    ProviderIds = request.NewMovieProviderIds,
+                    ProviderIds = request.NewMovieProviderIds.ToDictionary(x => x.Key, x => x.Value),
                 };
 
                 var newPath = GetMoviePath(result.OriginalPath, movie, options);

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -443,10 +443,9 @@ namespace Emby.AutoOrganize.Core
                 if (finalResult != null)
                 {
                     // We are in the good position, we can create the item
-                    var organizationRequest = new MovieFileOrganizationRequest
+                    var organizationRequest = new MovieFileOrganizationRequest(finalResult.ProviderIds)
                     {
                         NewMovieName = finalResult.Name,
-                        NewMovieProviderIds = finalResult.ProviderIds,
                         NewMovieYear = finalResult.ProductionYear,
                         TargetFolder = options.DefaultMovieLibraryPath
                     };

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -254,7 +254,7 @@ namespace Emby.AutoOrganize.Core
                 cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task OrganizeMovie(
+        private Task OrganizeMovie(
             string sourcePath,
             Movie movie,
             MovieFileOrganizationOptions options,
@@ -293,7 +293,7 @@ namespace Emby.AutoOrganize.Core
                         _logger.LogInformation(msg);
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
-                        return;
+                        return Task.CompletedTask;
                     }
 
                     if (fileExists)
@@ -303,7 +303,7 @@ namespace Emby.AutoOrganize.Core
                         result.Status = FileSortingStatus.SkippedExisting;
                         result.StatusMessage = msg;
                         result.TargetPath = newPath;
-                        return;
+                        return Task.CompletedTask;
                     }
                 }
 
@@ -324,6 +324,8 @@ namespace Emby.AutoOrganize.Core
             {
                 _organizationService.RemoveFromInprogressList(result);
             }
+
+            return Task.CompletedTask;
         }
 
         private void PerformFileSorting(MovieFileOrganizationOptions options, FileOrganizationResult result)

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -443,9 +443,10 @@ namespace Emby.AutoOrganize.Core
                 if (finalResult != null)
                 {
                     // We are in the good position, we can create the item
-                    var organizationRequest = new MovieFileOrganizationRequest(finalResult.ProviderIds)
+                    var organizationRequest = new MovieFileOrganizationRequest
                     {
                         NewMovieName = finalResult.Name,
+                        NewMovieProviderIds = finalResult.ProviderIds,
                         NewMovieYear = finalResult.ProductionYear,
                         TargetFolder = options.DefaultMovieLibraryPath
                     };

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -221,7 +221,7 @@ namespace Emby.AutoOrganize.Core
             FileOrganizationResult result,
             CancellationToken cancellationToken)
         {
-            var movie = GetMatchingMovie(movieName, movieYear, "", result);
+            var movie = GetMatchingMovie(movieName, movieYear, string.Empty, result);
             RemoteSearchResult searchResult = null;
 
             if (movie == null)

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -27,15 +27,17 @@ namespace Emby.AutoOrganize.Core
         private readonly ILogger _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
-        private readonly IServerConfigurationManager _config;
         private readonly IProviderManager _providerManager;
 
-        private readonly CultureInfo _usCulture = new CultureInfo("en-US");
-
-        public MovieFileOrganizer(IFileOrganizationService organizationService, IServerConfigurationManager config, IFileSystem fileSystem, ILogger logger, ILibraryManager libraryManager, ILibraryMonitor libraryMonitor, IProviderManager providerManager)
+        public MovieFileOrganizer(
+            IFileOrganizationService organizationService,
+            IFileSystem fileSystem,
+            ILogger logger,
+            ILibraryManager libraryManager,
+            ILibraryMonitor libraryMonitor,
+            IProviderManager providerManager)
         {
             _organizationService = organizationService;
-            _config = config;
             _fileSystem = fileSystem;
             _logger = logger;
             _libraryManager = libraryManager;

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -414,7 +414,7 @@ namespace Emby.AutoOrganize.Core
                 {
                     SearchInfo = movieInfo
 
-                }, cancellationToken);
+                }, cancellationToken).ConfigureAwait(false);
 
                 #endregion
 

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -140,7 +140,7 @@ namespace Emby.AutoOrganize.Core
             return result;
         }
 
-        private Movie CreateNewMovie(MovieFileOrganizationRequest request, FileOrganizationResult result, MovieFileOrganizationOptions options, CancellationToken cancellationToken)
+        private Movie CreateNewMovie(MovieFileOrganizationRequest request, FileOrganizationResult result, MovieFileOrganizationOptions options)
         {
             // To avoid Movie duplicate by mistake (Missing SmartMatch and wrong selection in UI)
             var movie = GetMatchingMovie(request.NewMovieName, request.NewMovieYear, request.TargetFolder, result);
@@ -182,7 +182,7 @@ namespace Emby.AutoOrganize.Core
                 if (request.NewMovieProviderIds.Count > 0)
                 {
                     // To avoid Series duplicate by mistake (Missing SmartMatch and wrong selection in UI)
-                    movie = CreateNewMovie(request, result, options, cancellationToken);
+                    movie = CreateNewMovie(request, result, options);
                 }
 
                 if (movie == null)
@@ -451,7 +451,7 @@ namespace Emby.AutoOrganize.Core
                         TargetFolder = options.DefaultMovieLibraryPath
                     };
 
-                    var movie = CreateNewMovie(organizationRequest, result, options, cancellationToken);
+                    var movie = CreateNewMovie(organizationRequest, result, options);
 
                     return new Tuple<Movie, RemoteSearchResult>(movie, finalResult);
                 }

--- a/Emby.AutoOrganize/Core/MovieFolderOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFolderOrganizer.cs
@@ -73,7 +73,10 @@ namespace Emby.AutoOrganize.Core
             return libraryFolderPaths.Any(i => string.Equals(i, path, StringComparison.Ordinal) || _fileSystem.ContainsSubPath(i, path));
         }
 
-        public async Task Organize(MovieFileOrganizationOptions options, CancellationToken cancellationToken, IProgress<double> progress)
+        public async Task Organize(
+            MovieFileOrganizationOptions options,
+            IProgress<double> progress,
+            CancellationToken cancellationToken)
         {
             var libraryFolderPaths = _libraryManager.GetVirtualFolders().SelectMany(i => i.Locations).ToList();
 
@@ -94,8 +97,7 @@ namespace Emby.AutoOrganize.Core
             {
                 var numComplete = 0;
 
-                var organizer = new MovieFileOrganizer(_organizationService, _config, _fileSystem, _logger, _libraryManager,
-                    _libraryMonitor, _providerManager);
+                var organizer = new MovieFileOrganizer(_organizationService, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
 
                 foreach (var file in eligibleFiles)
                 {

--- a/Emby.AutoOrganize/Core/OrganizerScheduledTask.cs
+++ b/Emby.AutoOrganize/Core/OrganizerScheduledTask.cs
@@ -63,7 +63,7 @@ namespace Emby.AutoOrganize.Core
                 var fileOrganizationService = PluginEntryPoint.Current.FileOrganizationService;
 
                 await new TvFolderOrganizer(_libraryManager, _logger, _fileSystem, _libraryMonitor, fileOrganizationService, _config, _providerManager)
-                    .Organize(options.TvOptions, cancellationToken, progress).ConfigureAwait(false);
+                    .Organize(options.TvOptions, progress, cancellationToken).ConfigureAwait(false);
             }
 
             //var queueMovie = false;
@@ -73,7 +73,7 @@ namespace Emby.AutoOrganize.Core
                 var fileOrganizationService = PluginEntryPoint.Current.FileOrganizationService;
 
                 await new MovieFolderOrganizer(_libraryManager, _logger, _fileSystem, _libraryMonitor, fileOrganizationService, _config, _providerManager)
-                    .Organize(options.MovieOptions, cancellationToken, progress).ConfigureAwait(false);
+                    .Organize(options.MovieOptions, progress, cancellationToken).ConfigureAwait(false);
             }
 
             if ((queueTv || queueMovie) && !_libraryManager.IsScanRunning)

--- a/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
+++ b/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
@@ -90,8 +90,7 @@ namespace Emby.AutoOrganize.Core
             {
                 var numComplete = 0;
 
-                var organizer = new EpisodeFileOrganizer(_organizationService, _config, _fileSystem, _logger, _libraryManager,
-                    _libraryMonitor, _providerManager);
+                var organizer = new EpisodeFileOrganizer(_organizationService, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
 
                 foreach (var file in eligibleFiles)
                 {

--- a/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
+++ b/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
@@ -66,8 +66,10 @@ namespace Emby.AutoOrganize.Core
             return libraryFolderPaths.Any(i => string.Equals(i, path, StringComparison.Ordinal) || _fileSystem.ContainsSubPath(i, path));
         }
 
-        public async Task Organize(TvFileOrganizationOptions options,
-            CancellationToken cancellationToken, IProgress<double> progress)
+        public async Task Organize(
+            TvFileOrganizationOptions options,
+            IProgress<double> progress,
+            CancellationToken cancellationToken)
         {
             var libraryFolderPaths = _libraryManager.GetVirtualFolders().SelectMany(i => i.Locations).ToList();
 

--- a/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
+++ b/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
@@ -269,32 +269,31 @@ namespace Emby.AutoOrganize.Data
             return exp;
         }
 
-        private bool _disposed;
-        protected void CheckDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(GetType().Name + " has been disposed and cannot be accessed.");
-            }
-        }
+        #region IDisposable Support
+        private bool _disposed = false;
+        private readonly object _disposeLock = new object();
 
         public void Dispose()
         {
-            _disposed = true;
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
-
-        private readonly object _disposeLock = new object();
 
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
         /// <param name="dispose"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool dispose)
+        protected virtual void Dispose(bool disposing)
         {
-            if (dispose)
+            if (!_disposed)
             {
-                DisposeConnection();
+                if (disposing)
+                {
+                    // Dispose managed state
+                    DisposeConnection();
+                }
+
+                _disposed = true;
             }
         }
 
@@ -319,6 +318,7 @@ namespace Emby.AutoOrganize.Data
                 _logger.LogError(ex, "Error disposing database", ex);
             }
         }
+        #endregion
 
         protected List<string> GetColumnNames(IDatabaseConnection connection, string table)
         {

--- a/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
+++ b/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
@@ -288,11 +288,8 @@ namespace Emby.AutoOrganize.Data
                 {
                     using (WriteLock.Write())
                     {
-                        if (_dbConnection != null)
-                        {
-                            _dbConnection.Dispose();
-                            _connection.Dispose();
-                        }
+                        _connection?.Dispose();
+                        _dbConnection?.Dispose();
                     }
                 }
             }

--- a/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
+++ b/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
@@ -268,16 +268,15 @@ namespace Emby.AutoOrganize.Data
         /// <param name="dispose"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    // Dispose managed state
-                    DisposeConnection();
-                }
+            if (_disposed) return;
 
-                _disposed = true;
+            if (disposing)
+            {
+                // Dispose managed state
+                DisposeConnection();
             }
+
+            _disposed = true;
         }
 
         private void DisposeConnection()

--- a/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
+++ b/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
@@ -13,14 +13,13 @@ namespace Emby.AutoOrganize.Data
     public abstract class BaseSqliteRepository : IDisposable
     {
         protected string DbFilePath { get; set; }
-        protected ReaderWriterLockSlim WriteLock;
+        protected ReaderWriterLockSlim WriteLock { get; }
 
-        protected ILogger _logger { get; private set; }
+        private readonly ILogger _logger;
 
         protected BaseSqliteRepository(ILogger logger)
         {
             _logger = logger;
-
             WriteLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
         }
 
@@ -56,7 +55,7 @@ namespace Emby.AutoOrganize.Data
         private static bool _versionLogged;
 
         private string _defaultWal;
-        protected ManagedConnection _connection;
+        private ManagedConnection _connection;
 
         protected virtual bool EnableSingleConnection
         {
@@ -75,8 +74,8 @@ namespace Emby.AutoOrganize.Data
                 if (!_versionLogged)
                 {
                     _versionLogged = true;
-                    _logger.LogInformation("Sqlite version: {ver}", SQLite3.Version);
-                    _logger.LogInformation("Sqlite compiler options: {opts}", string.Join(",", SQLite3.CompilerOptions.ToArray()));
+                    _logger.LogInformation("SQLite version: {Version}", SQLite3.Version);
+                    _logger.LogInformation("SQLite compiler options: {Options}", string.Join(",", SQLite3.CompilerOptions));
                 }
 
                 ConnectionFlags connectionFlags;
@@ -400,13 +399,6 @@ namespace Emby.AutoOrganize.Data
                     _sync.ExitWriteLock();
                     _sync = null;
                 }
-            }
-        }
-
-        public class DummyToken : IDisposable
-        {
-            public void Dispose()
-            {
             }
         }
 

--- a/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
+++ b/Emby.AutoOrganize/Data/BaseSqliteRepository.cs
@@ -252,23 +252,6 @@ namespace Emby.AutoOrganize.Data
             }
         }
 
-        internal static void CheckOk(int rc)
-        {
-            string msg = "";
-
-            if (raw.SQLITE_OK != rc)
-            {
-                throw CreateException((ErrorCode)rc, msg);
-            }
-        }
-
-        internal static Exception CreateException(ErrorCode rc, string msg)
-        {
-            var exp = new Exception(msg);
-
-            return exp;
-        }
-
         #region IDisposable Support
         private bool _disposed = false;
         private readonly object _disposeLock = new object();
@@ -308,7 +291,7 @@ namespace Emby.AutoOrganize.Data
                         if (_dbConnection != null)
                         {
                             _dbConnection.Dispose();
-                            _dbConnection = null;
+                            _connection.Dispose();
                         }
                     }
                 }

--- a/Emby.AutoOrganize/Data/ManagedConnection.cs
+++ b/Emby.AutoOrganize/Data/ManagedConnection.cs
@@ -7,15 +7,22 @@ using SQLitePCL.pretty;
 
 namespace Emby.AutoOrganize.Data
 {
-    public class ManagedConnection :  IDisposable
+    /// <summary>
+    /// Wraps a <see cref="SQLiteDatabaseConnection"/>.
+    /// </summary>
+    public sealed class ManagedConnection : IDisposable
     {
-        private SQLiteDatabaseConnection db;
-        private readonly bool _closeOnDispose;
+        private readonly SQLiteDatabaseConnection db;
 
-        public ManagedConnection(SQLiteDatabaseConnection db, bool closeOnDispose)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagedConnection"/> class by wrapping a
+        /// <see cref="SQLiteDatabaseConnection"/>. The caller of this constructor is responsible for disposing the
+        /// connection at an appropriate time.
+        /// </summary>
+        /// <param name="db">The database connection to wrap.</param>
+        public ManagedConnection(SQLiteDatabaseConnection db)
         {
             this.db = db;
-            _closeOnDispose = closeOnDispose;
         }
 
         public IStatement PrepareStatement(string sql)
@@ -50,7 +57,7 @@ namespace Emby.AutoOrganize.Data
 
         public T RunInTransaction<T>(Func<IDatabaseConnection, T> action, TransactionMode mode)
         {
-            return db.RunInTransaction<T>(action, mode);
+            return db.RunInTransaction(action, mode);
         }
 
         public IEnumerable<IReadOnlyList<IResultSetValue>> Query(string sql)
@@ -63,20 +70,11 @@ namespace Emby.AutoOrganize.Data
             return db.Query(sql, values);
         }
 
-        public void Close()
-        {
-            using (db)
-            {
-
-            }
-        }
-
         public void Dispose()
         {
-            if (_closeOnDispose)
-            {
-                Close();
-            }
+            // There is nothing to dispose in this class, the db connection is managed by BaseSqliteRepository.
+            // The IDisposable interface has been left on this class to reduce the amount of code changes necessary
+            // later on in case we decide to move management of the db connection down to this class.
         }
     }
 }

--- a/Emby.AutoOrganize/Data/SqliteExtensions.cs
+++ b/Emby.AutoOrganize/Data/SqliteExtensions.cs
@@ -128,7 +128,7 @@ namespace Emby.AutoOrganize.Data
 
         public static void Attach(ManagedConnection db, string path, string alias)
         {
-            var commandText = string.Format("attach @path as {0};", alias);
+            var commandText = $"attach @path as {alias};";
 
             using (var statement = db.PrepareStatement(commandText))
             {

--- a/Emby.AutoOrganize/Data/SqliteExtensions.cs
+++ b/Emby.AutoOrganize/Data/SqliteExtensions.cs
@@ -14,15 +14,11 @@ namespace Emby.AutoOrganize.Data
         {
             if (queries == null)
             {
-                throw new ArgumentNullException("queries");
+                throw new ArgumentNullException(nameof(queries));
             }
 
             connection.RunInTransaction(conn =>
             {
-                //foreach (var query in queries)
-                //{
-                //    conn.Execute(query);
-                //}
                 conn.ExecuteAll(string.Join(";", queries));
             });
         }
@@ -120,7 +116,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (obj == null)
             {
-                throw new ArgumentNullException("obj");
+                throw new ArgumentNullException(nameof(obj));
             }
 
             using (var stream = new MemoryStream())

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -507,7 +507,7 @@ namespace Emby.AutoOrganize.Data
             index++;
             if (reader[index].SQLiteType != SQLiteType.Null)
             {
-                result.MatchStrings = _json.DeserializeFromString<List<string>>(reader[index].ToString());
+                result.MatchStrings.AddRange(_json.DeserializeFromString<List<string>>(reader[index].ToString()));
             }
 
             return result;

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -170,11 +170,11 @@ namespace Emby.AutoOrganize.Data
 
                     if (query.StartIndex.HasValue && query.StartIndex.Value > 0)
                     {
-                        commandText += string.Format(" WHERE ResultId NOT IN (SELECT ResultId FROM FileOrganizerResults ORDER BY OrganizationDate desc LIMIT {0})",
-                            query.StartIndex.Value.ToString(_usCulture));
+                        var startIndex = query.StartIndex.Value.ToString(_usCulture);
+                        commandText += $" WHERE ResultId NOT IN (SELECT ResultId FROM FileOrganizerResults ORDER BY OrganizationDate DESC LIMIT {startIndex})";
                     }
 
-                    commandText += " ORDER BY OrganizationDate desc";
+                    commandText += " ORDER BY OrganizationDate DESC";
 
                     if (query.Limit.HasValue)
                     {
@@ -450,11 +450,11 @@ namespace Emby.AutoOrganize.Data
 
                     if (query.StartIndex.HasValue && query.StartIndex.Value > 0)
                     {
-                        commandText += string.Format(" WHERE Id NOT IN (SELECT Id FROM SmartMatch ORDER BY ItemName desc LIMIT {0})",
-                            query.StartIndex.Value.ToString(_usCulture));
+                        var startIndex = query.StartIndex.Value.ToString(_usCulture);
+                        commandText += $" WHERE Id NOT IN (SELECT Id FROM SmartMatch ORDER BY ItemName DESC LIMIT {startIndex})";
                     }
 
-                    commandText += " ORDER BY ItemName desc";
+                    commandText += " ORDER BY ItemName DESC";
 
                     if (query.Limit.HasValue)
                     {

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Emby.AutoOrganize.Model;
 using MediaBrowser.Controller;
-using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging;

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -15,12 +15,13 @@ using SQLitePCL.pretty;
 
 namespace Emby.AutoOrganize.Data
 {
-    public class SqliteFileOrganizationRepository : BaseSqliteRepository, IFileOrganizationRepository, IDisposable
+    public class SqliteFileOrganizationRepository : BaseSqliteRepository, IFileOrganizationRepository
     {
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");
         private readonly IJsonSerializer _json;
 
-        public SqliteFileOrganizationRepository(ILogger logger, IServerApplicationPaths appPaths, IJsonSerializer json) : base(logger)
+        public SqliteFileOrganizationRepository(ILogger logger, IServerApplicationPaths appPaths, IJsonSerializer json)
+            : base(logger)
         {
             _json = json;
             DbFilePath = Path.Combine(appPaths.DataPath, "fileorganization.db");
@@ -54,7 +55,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (result == null)
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -96,7 +97,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             using (WriteLock.Write())
@@ -153,7 +154,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             using (WriteLock.Read())
@@ -203,7 +204,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             using (WriteLock.Read())
@@ -230,7 +231,7 @@ namespace Emby.AutoOrganize.Data
 
             var result = new FileOrganizationResult
             {
-                Id = reader[0].ReadGuidFromBlob().ToString("N")
+                Id = reader[0].ReadGuidFromBlob().ToString("N", CultureInfo.InvariantCulture)
             };
 
             index++;
@@ -312,7 +313,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (result == null)
             {
-                throw new ArgumentNullException("result");
+                throw new ArgumentNullException(nameof(result));
             }
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -345,7 +346,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             using (WriteLock.Write())
@@ -368,7 +369,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             var match = GetSmartMatch(id);
@@ -405,7 +406,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (string.IsNullOrEmpty(id))
             {
-                throw new ArgumentNullException("id");
+                throw new ArgumentNullException(nameof(id));
             }
 
             using (WriteLock.Read())
@@ -431,7 +432,7 @@ namespace Emby.AutoOrganize.Data
         {
             if (query == null)
             {
-                throw new ArgumentNullException("query");
+                throw new ArgumentNullException(nameof(query));
             }
 
             using (WriteLock.Read())

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -304,8 +304,7 @@ namespace Emby.AutoOrganize.Data
             index++;
             if (reader[index].SQLiteType != SQLiteType.Null)
             {
-                var duplicatePaths = reader[index].ToString().Split('|').Where(i => !string.IsNullOrEmpty(i));
-                result.DuplicatePaths.AddRange(duplicatePaths);
+                result.DuplicatePaths = reader[index].ToString().Split('|').Where(i => !string.IsNullOrEmpty(i)).ToList();
             }
 
             return result;
@@ -508,8 +507,7 @@ namespace Emby.AutoOrganize.Data
             index++;
             if (reader[index].SQLiteType != SQLiteType.Null)
             {
-                var matchStrings = _json.DeserializeFromString<List<string>>(reader[index].ToString());
-                result.MatchStrings.AddRange(matchStrings);
+                result.MatchStrings = _json.DeserializeFromString<List<string>>(reader[index].ToString());
             }
 
             return result;

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -304,7 +304,8 @@ namespace Emby.AutoOrganize.Data
             index++;
             if (reader[index].SQLiteType != SQLiteType.Null)
             {
-                result.DuplicatePaths = reader[index].ToString().Split('|').Where(i => !string.IsNullOrEmpty(i)).ToList();
+                var duplicatePaths = reader[index].ToString().Split('|').Where(i => !string.IsNullOrEmpty(i));
+                result.DuplicatePaths.AddRange(duplicatePaths);
             }
 
             return result;
@@ -507,7 +508,8 @@ namespace Emby.AutoOrganize.Data
             index++;
             if (reader[index].SQLiteType != SQLiteType.Null)
             {
-                result.MatchStrings = _json.DeserializeFromString<List<string>>(reader[index].ToString());
+                var matchStrings = _json.DeserializeFromString<List<string>>(reader[index].ToString());
+                result.MatchStrings.AddRange(matchStrings);
             }
 
             return result;

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -92,7 +92,7 @@ namespace Emby.AutoOrganize.Data
             }
         }
 
-        public async Task Delete(string id)
+        public Task Delete(string id)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -113,9 +113,11 @@ namespace Emby.AutoOrganize.Data
                     }, TransactionMode);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public async Task DeleteAll()
+        public Task DeleteAll()
         {
             using (WriteLock.Write())
             {
@@ -129,9 +131,11 @@ namespace Emby.AutoOrganize.Data
                     }, TransactionMode);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public async Task DeleteCompleted()
+        public Task DeleteCompleted()
         {
             using (WriteLock.Write())
             {
@@ -147,6 +151,8 @@ namespace Emby.AutoOrganize.Data
                     }, TransactionMode);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         public QueryResult<FileOrganizationResult> GetResults(FileOrganizationResultQuery query)
@@ -364,7 +370,7 @@ namespace Emby.AutoOrganize.Data
             }
         }
 
-        public async Task DeleteSmartMatch(string id, string matchString)
+        public Task DeleteSmartMatch(string id, string matchString)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -383,6 +389,8 @@ namespace Emby.AutoOrganize.Data
             {
                 DeleteSmartMatch(id);
             }
+
+            return Task.CompletedTask;
         }
 
         public void DeleteAllSmartMatch()

--- a/Emby.AutoOrganize/Emby.AutoOrganize.csproj
+++ b/Emby.AutoOrganize/Emby.AutoOrganize.csproj
@@ -42,7 +42,7 @@
 
   <!-- Code Analyzers-->
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="All" />
     <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" /> -->
   </ItemGroup>
 

--- a/Emby.AutoOrganize/Emby.AutoOrganize.csproj
+++ b/Emby.AutoOrganize/Emby.AutoOrganize.csproj
@@ -40,4 +40,14 @@
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="2.0.1" />
   </ItemGroup>
 
+  <!-- Code Analyzers-->
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.7" PrivateAssets="All" />
+    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" /> -->
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
 </Project>

--- a/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
+++ b/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Emby.AutoOrganize.Model
 {
@@ -21,6 +22,7 @@ namespace Emby.AutoOrganize.Model
         /// Gets or sets a list of smart match entries.
         /// </summary>
         /// <value>The smart match entries.</value>
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<SmartMatchInfo> SmartMatchInfos { get; set; }
 
         public bool Converted { get; set; }

--- a/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
+++ b/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
@@ -26,7 +26,7 @@ namespace Emby.AutoOrganize.Model
         {
             TvOptions = new TvFileOrganizationOptions();
             MovieOptions = new MovieFileOrganizationOptions();
-            SmartMatchInfos = new SmartMatchInfo[] { };
+            SmartMatchInfos = Array.Empty<SmartMatchInfo>();
             Converted = false;
         }
     }

--- a/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
+++ b/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Emby.AutoOrganize.Model
 {
     public class AutoOrganizeOptions

--- a/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
+++ b/Emby.AutoOrganize/Model/AutoOrganizeOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Emby.AutoOrganize.Model
 {
@@ -20,7 +21,7 @@ namespace Emby.AutoOrganize.Model
         /// Gets or sets a list of smart match entries.
         /// </summary>
         /// <value>The smart match entries.</value>
-        public SmartMatchInfo[] SmartMatchInfos { get; set; }
+        public List<SmartMatchInfo> SmartMatchInfos { get; set; }
 
         public bool Converted { get; set; }
 
@@ -28,7 +29,7 @@ namespace Emby.AutoOrganize.Model
         {
             TvOptions = new TvFileOrganizationOptions();
             MovieOptions = new MovieFileOrganizationOptions();
-            SmartMatchInfos = Array.Empty<SmartMatchInfo>();
+            SmartMatchInfos = new List<SmartMatchInfo>();
             Converted = false;
         }
     }

--- a/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
@@ -21,6 +21,11 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewSeriesProviderIds { get; set; }
+        public Dictionary<string, string> NewSeriesProviderIds { get; }
+
+        public EpisodeFileOrganizationRequest(Dictionary<string, string> newSeriesProviderIds)
+        {
+            NewSeriesProviderIds = newSeriesProviderIds ?? new Dictionary<string, string>();
+        }
     }
 }

--- a/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
@@ -21,6 +21,6 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewSeriesProviderIds { get; set; }
+        public IReadOnlyDictionary<string, string> NewSeriesProviderIds { get; set; }
     }
 }

--- a/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/EpisodeFileOrganizationRequest.cs
@@ -21,11 +21,6 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewSeriesProviderIds { get; }
-
-        public EpisodeFileOrganizationRequest(Dictionary<string, string> newSeriesProviderIds)
-        {
-            NewSeriesProviderIds = newSeriesProviderIds ?? new Dictionary<string, string>();
-        }
+        public Dictionary<string, string> NewSeriesProviderIds { get; set; }
     }
 }

--- a/Emby.AutoOrganize/Model/FileOrganizationResult.cs
+++ b/Emby.AutoOrganize/Model/FileOrganizationResult.cs
@@ -87,7 +87,7 @@ namespace Emby.AutoOrganize.Model
         /// Gets or sets the duplicate paths.
         /// </summary>
         /// <value>The duplicate paths.</value>
-        public List<string> DuplicatePaths { get; set; }
+        public List<string> DuplicatePaths { get; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the size of the file.

--- a/Emby.AutoOrganize/Model/FileOrganizationResult.cs
+++ b/Emby.AutoOrganize/Model/FileOrganizationResult.cs
@@ -87,7 +87,7 @@ namespace Emby.AutoOrganize.Model
         /// Gets or sets the duplicate paths.
         /// </summary>
         /// <value>The duplicate paths.</value>
-        public List<string> DuplicatePaths { get; set; }
+        public IReadOnlyList<string> DuplicatePaths { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the file.
@@ -103,7 +103,7 @@ namespace Emby.AutoOrganize.Model
 
         public FileOrganizationResult()
         {
-            DuplicatePaths = new List<string>();
+            DuplicatePaths = new List<string>().AsReadOnly();
         }
     }
 }

--- a/Emby.AutoOrganize/Model/FileOrganizationResult.cs
+++ b/Emby.AutoOrganize/Model/FileOrganizationResult.cs
@@ -87,7 +87,7 @@ namespace Emby.AutoOrganize.Model
         /// Gets or sets the duplicate paths.
         /// </summary>
         /// <value>The duplicate paths.</value>
-        public List<string> DuplicatePaths { get; } = new List<string>();
+        public List<string> DuplicatePaths { get; set; }
 
         /// <summary>
         /// Gets or sets the size of the file.

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Emby.AutoOrganize.Model
 {
     public class MovieFileOrganizationOptions
@@ -31,11 +33,11 @@ namespace Emby.AutoOrganize.Model
         {
             MinFileSizeMb = 50;
 
-            LeftOverFileExtensionsToDelete = new string[] { };
+            LeftOverFileExtensionsToDelete = Array.Empty<string>();
 
             MoviePattern = "%fn.%ext";
 
-            WatchLocations = new string[] { };
+            WatchLocations = Array.Empty<string>();
 
             CopyOriginalFile = false;
 

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Collections.Generic;
 
 namespace Emby.AutoOrganize.Model
 {
     public class MovieFileOrganizationOptions
     {
         public bool IsEnabled { get; set; }
+
         public int MinFileSizeMb { get; set; }
-        public string[] LeftOverFileExtensionsToDelete { get; set; }
-        public string[] WatchLocations { get; set; }
+
+        public List<string> LeftOverFileExtensionsToDelete { get; set; }
+
+        public List<string> WatchLocations { get; set; }
 
         public string MoviePattern { get; set; }
 
@@ -33,11 +37,11 @@ namespace Emby.AutoOrganize.Model
         {
             MinFileSizeMb = 50;
 
-            LeftOverFileExtensionsToDelete = Array.Empty<string>();
+            LeftOverFileExtensionsToDelete =  new List<string>();
 
             MoviePattern = "%fn.%ext";
 
-            WatchLocations = Array.Empty<string>();
+            WatchLocations = new List<string>();
 
             CopyOriginalFile = false;
 

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Emby.AutoOrganize.Model
 {
@@ -9,8 +10,10 @@ namespace Emby.AutoOrganize.Model
 
         public int MinFileSizeMb { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<string> LeftOverFileExtensionsToDelete { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<string> WatchLocations { get; set; }
 
         public string MoviePattern { get; set; }

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationOptions.cs
@@ -37,7 +37,7 @@ namespace Emby.AutoOrganize.Model
         {
             MinFileSizeMb = 50;
 
-            LeftOverFileExtensionsToDelete =  new List<string>();
+            LeftOverFileExtensionsToDelete = new List<string>();
 
             MoviePattern = "%fn.%ext";
 

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
@@ -14,6 +14,6 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewMovieProviderIds { get; set; }
+        public IReadOnlyDictionary<string, string> NewMovieProviderIds { get; set; }
     }
 }

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
@@ -14,6 +14,11 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewMovieProviderIds { get; set; }
+        public Dictionary<string, string> NewMovieProviderIds { get; }
+
+        public MovieFileOrganizationRequest(Dictionary<string, string> newMovieProviderIds = null)
+        {
+            NewMovieProviderIds = newMovieProviderIds ?? new Dictionary<string, string>();
+        }
     }
 }

--- a/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
+++ b/Emby.AutoOrganize/Model/MovieFileOrganizationRequest.cs
@@ -14,11 +14,6 @@ namespace Emby.AutoOrganize.Model
 
         public string TargetFolder { get; set; }
 
-        public Dictionary<string, string> NewMovieProviderIds { get; }
-
-        public MovieFileOrganizationRequest(Dictionary<string, string> newMovieProviderIds = null)
-        {
-            NewMovieProviderIds = newMovieProviderIds ?? new Dictionary<string, string>();
-        }
+        public Dictionary<string, string> NewMovieProviderIds { get; set; }
     }
 }

--- a/Emby.AutoOrganize/Model/SmartMatchInfo.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchInfo.cs
@@ -12,7 +12,7 @@ namespace Emby.AutoOrganize.Model
 
         public SmartMatchInfo()
         {
-            MatchStrings = new string[] { };
+            MatchStrings = Array.Empty<string>();
         }
     }
 }

--- a/Emby.AutoOrganize/Model/SmartMatchInfo.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchInfo.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Emby.AutoOrganize.Model
 {
@@ -8,6 +9,7 @@ namespace Emby.AutoOrganize.Model
         public string ItemName { get; set; }
         public string DisplayName { get; set; }
         public FileOrganizerType OrganizerType { get; set; }
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<string> MatchStrings { get; set; }
 
         public SmartMatchInfo()

--- a/Emby.AutoOrganize/Model/SmartMatchInfo.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchInfo.cs
@@ -8,11 +8,11 @@ namespace Emby.AutoOrganize.Model
         public string ItemName { get; set; }
         public string DisplayName { get; set; }
         public FileOrganizerType OrganizerType { get; set; }
-        public string[] MatchStrings { get; set; }
+        public List<string> MatchStrings { get; set; }
 
         public SmartMatchInfo()
         {
-            MatchStrings = Array.Empty<string>();
+            MatchStrings = new List<string>();
         }
     }
 }

--- a/Emby.AutoOrganize/Model/SmartMatchResult.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchResult.cs
@@ -5,7 +5,7 @@ namespace Emby.AutoOrganize.Model
 {
     public class SmartMatchResult
     {
-        public Guid Id { get; set; } = Guid.NewGuid();
+        public Guid Id { get; set; }
 
         public string ItemName { get; set; }
         
@@ -13,6 +13,12 @@ namespace Emby.AutoOrganize.Model
         
         public FileOrganizerType OrganizerType { get; set; }
 
-        public List<string> MatchStrings { get; set; } = new List<string>();
+        public List<string> MatchStrings { get; set; }
+
+        public SmartMatchResult()
+        {
+            Id = Guid.NewGuid();
+            MatchStrings = new List<string>();
+        }
     }
 }

--- a/Emby.AutoOrganize/Model/SmartMatchResult.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchResult.cs
@@ -13,6 +13,6 @@ namespace Emby.AutoOrganize.Model
         
         public FileOrganizerType OrganizerType { get; set; }
 
-        public List<string> MatchStrings { get; } = new List<string>();
+        public List<string> MatchStrings { get; set; } = new List<string>();
     }
 }

--- a/Emby.AutoOrganize/Model/SmartMatchResult.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchResult.cs
@@ -13,7 +13,7 @@ namespace Emby.AutoOrganize.Model
         
         public FileOrganizerType OrganizerType { get; set; }
 
-        public List<string> MatchStrings { get; set; }
+        public List<string> MatchStrings { get; }
 
         public SmartMatchResult()
         {

--- a/Emby.AutoOrganize/Model/SmartMatchResult.cs
+++ b/Emby.AutoOrganize/Model/SmartMatchResult.cs
@@ -5,16 +5,14 @@ namespace Emby.AutoOrganize.Model
 {
     public class SmartMatchResult
     {
-        public Guid Id { get; set; }
-        public string ItemName { get; set; }
-        public string DisplayName { get; set; }
-        public FileOrganizerType OrganizerType { get; set; }
-        public List<string> MatchStrings { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
-        public SmartMatchResult()
-        {
-            Id = Guid.NewGuid();
-            MatchStrings = new List<string>();
-        }
+        public string ItemName { get; set; }
+        
+        public string DisplayName { get; set; }
+        
+        public FileOrganizerType OrganizerType { get; set; }
+
+        public List<string> MatchStrings { get; } = new List<string>();
     }
 }

--- a/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Emby.AutoOrganize.Model
 {
     public class TvFileOrganizationOptions
@@ -34,9 +36,9 @@ namespace Emby.AutoOrganize.Model
         {
             MinFileSizeMb = 50;
 
-            LeftOverFileExtensionsToDelete = new string[] { };
+            LeftOverFileExtensionsToDelete = Array.Empty<string>();
 
-            WatchLocations = new string[] { };
+            WatchLocations = Array.Empty<string>();
 
             EpisodeNamePattern = "%sn - %sx%0e - %en.%ext";
             MultiEpisodeNamePattern = "%sn - %sx%0e-x%0ed - %en.%ext";

--- a/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Emby.AutoOrganize.Model
 {
@@ -9,8 +10,10 @@ namespace Emby.AutoOrganize.Model
 
         public int MinFileSizeMb { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<string> LeftOverFileExtensionsToDelete { get; set; }
 
+        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "This property needs to support serialization by both ServiceStack and XmlSerializer")]
         public List<string> WatchLocations { get; set; }
 
         public string SeasonFolderPattern { get; set; }

--- a/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
+++ b/Emby.AutoOrganize/Model/TvFileOrganizationOptions.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Collections.Generic;
 
 namespace Emby.AutoOrganize.Model
 {
     public class TvFileOrganizationOptions
     {
         public bool IsEnabled { get; set; }
+
         public int MinFileSizeMb { get; set; }
-        public string[] LeftOverFileExtensionsToDelete { get; set; }
-        public string[] WatchLocations { get; set; }
+
+        public List<string> LeftOverFileExtensionsToDelete { get; set; }
+
+        public List<string> WatchLocations { get; set; }
 
         public string SeasonFolderPattern { get; set; }
 
@@ -36,9 +40,9 @@ namespace Emby.AutoOrganize.Model
         {
             MinFileSizeMb = 50;
 
-            LeftOverFileExtensionsToDelete = Array.Empty<string>();
+            LeftOverFileExtensionsToDelete = new List<string>();
 
-            WatchLocations = Array.Empty<string>();
+            WatchLocations = new List<string>();
 
             EpisodeNamePattern = "%sn - %sx%0e - %en.%ext";
             MultiEpisodeNamePattern = "%sn - %sx%0e-x%0ed - %en.%ext";

--- a/Emby.AutoOrganize/PluginEntryPoint.cs
+++ b/Emby.AutoOrganize/PluginEntryPoint.cs
@@ -19,11 +19,11 @@ namespace Emby.AutoOrganize
 {
     public class PluginEntryPoint : IServerEntryPoint
     {
-        public static PluginEntryPoint Current;
+        public static PluginEntryPoint Current { get; private set; }
 
         public IFileOrganizationService FileOrganizationService { get; private set; }
+        
         private readonly ISessionManager _sessionManager;
-
         private readonly ITaskManager _taskManager;
         private readonly ILogger _logger;
         private readonly ILibraryMonitor _libraryMonitor;
@@ -33,7 +33,7 @@ namespace Emby.AutoOrganize
         private readonly IProviderManager _providerManager;
         private readonly IJsonSerializer _json;
 
-        public IFileOrganizationRepository Repository;
+        private IFileOrganizationRepository Repository;
 
         public PluginEntryPoint(
             ISessionManager sessionManager,

--- a/Emby.AutoOrganize/PluginEntryPoint.cs
+++ b/Emby.AutoOrganize/PluginEntryPoint.cs
@@ -33,7 +33,7 @@ namespace Emby.AutoOrganize
         private readonly IProviderManager _providerManager;
         private readonly IJsonSerializer _json;
 
-        private IFileOrganizationRepository Repository;
+        private IFileOrganizationRepository _repository;
 
         public PluginEntryPoint(
             ISessionManager sessionManager,
@@ -61,7 +61,7 @@ namespace Emby.AutoOrganize
         {
             try
             {
-                Repository = GetRepository();
+                _repository = GetRepository();
             }
             catch (Exception ex)
             {
@@ -69,7 +69,7 @@ namespace Emby.AutoOrganize
             }
 
             Current = this;
-            FileOrganizationService = new FileOrganizationService(_taskManager, Repository, _logger, _libraryMonitor, _libraryManager, _config, _fileSystem, _providerManager);
+            FileOrganizationService = new FileOrganizationService(_taskManager, _repository, _logger, _libraryMonitor, _libraryManager, _config, _fileSystem, _providerManager);
 
             FileOrganizationService.ItemAdded += _organizationService_ItemAdded;
             FileOrganizationService.ItemRemoved += _organizationService_ItemRemoved;
@@ -118,7 +118,7 @@ namespace Emby.AutoOrganize
             FileOrganizationService.ItemUpdated -= _organizationService_ItemUpdated;
             FileOrganizationService.LogReset -= _organizationService_LogReset;
 
-            var repo = Repository as IDisposable;
+            var repo = _repository as IDisposable;
             if (repo != null)
             {
                 repo.Dispose();

--- a/Emby.AutoOrganize/PluginEntryPoint.cs
+++ b/Emby.AutoOrganize/PluginEntryPoint.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Emby.AutoOrganize
 {
-    public class PluginEntryPoint : IServerEntryPoint
+    public sealed class PluginEntryPoint : IServerEntryPoint
     {
         public static PluginEntryPoint Current { get; private set; }
 

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Emby.AutoOrganize" Description="Code analysis rules for Emby.AutoOrganize.csproj" ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- disable warning CA1032: Implement standard exception constructors -->
+    <Rule Id="CA1032" Action="Info" />
+    <!-- disable warning SA1202: 'public' members must come before 'private' members -->
+    <Rule Id="SA1202" Action="Info" />
+    <!-- disable warning SA1204: Static members must appear before non-static members -->
+    <Rule Id="SA1204" Action="Info" />
+
+    <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
+    <Rule Id="SA1009" Action="None" />
+    <!-- disable warning SA1101: Prefix local calls with 'this.' -->
+    <Rule Id="SA1101" Action="None" />
+    <!-- disable warning SA1108: Block statements should not contain embedded comments -->
+    <Rule Id="SA1108" Action="None" />
+    <!-- disable warning SA1128:: Put constructor initializers on their own line -->
+    <Rule Id="SA1128" Action="None" />
+    <!-- disable warning SA1130: Use lambda syntax -->
+    <Rule Id="SA1130" Action="None" />
+    <!-- disable warning SA1200: 'using' directive must appear within a namespace declaration -->
+    <Rule Id="SA1200" Action="None" />
+    <!-- disable warning SA1309: Fields must not begin with an underscore -->
+    <Rule Id="SA1309" Action="None" />
+    <!-- disable warning SA1413: Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1413" Action="None" />
+    <!-- disable warning SA1512: Single-line comments must not be followed by blank line -->
+    <Rule Id="SA1512" Action="None" />
+    <!-- disable warning SA1633: The file header is missing or not located at the top of the file -->
+    <Rule Id="SA1633" Action="None" />
+  </Rules>
+
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.Design">
+    <!-- disable warning CA1031: Do not catch general exception types -->
+    <Rule Id="CA1031" Action="Info" />
+    <!-- disable warning CA1062: Validate arguments of public methods -->
+    <Rule Id="CA1062" Action="Info" />
+    <!-- disable warning CA1720: Identifiers should not contain type names -->
+    <Rule Id="CA1720" Action="Info" />
+    <!-- disable warning CA1812: internal class that is apparently never instantiated.
+        If so, remove the code from the assembly.
+        If this class is intended to contain only static members, make it static -->
+    <Rule Id="CA1812" Action="Info" />
+    <!-- disable warning CA1822: Member does not access instance data and can be marked as static -->
+    <Rule Id="CA1822" Action="Info" />
+
+    <!-- disable warning CA1054: Change the type of parameter url from string to System.Uri -->
+    <Rule Id="CA1054" Action="None" />
+    <!-- disable warning CA1303: Do not pass literals as localized parameters -->
+    <Rule Id="CA1303" Action="None" />
+    <!-- disable warning CA1308: Normalize strings to uppercase -->
+    <Rule Id="CA1308" Action="None" />
+    <!-- disable warning CA2000: Dispose objects before losing scope -->
+    <Rule Id="CA2000" Action="None" />
+  </Rules>
+</RuleSet>

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -7,6 +7,8 @@
     <Rule Id="SA1202" Action="Info" />
     <!-- disable warning SA1204: Static members must appear before non-static members -->
     <Rule Id="SA1204" Action="Info" />
+    <!-- disable warning CA2227: Collection properties should be read only -->
+    <Rule Id="CA2227" Action="Info" />
 
     <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
     <Rule Id="SA1009" Action="None" />

--- a/jellyfin.ruleset
+++ b/jellyfin.ruleset
@@ -7,8 +7,6 @@
     <Rule Id="SA1202" Action="Info" />
     <!-- disable warning SA1204: Static members must appear before non-static members -->
     <Rule Id="SA1204" Action="Info" />
-    <!-- disable warning CA2227: Collection properties should be read only -->
-    <Rule Id="CA2227" Action="Info" />
 
     <!-- disable warning SA1009: Closing parenthesis should be followed by a space. -->
     <Rule Id="SA1009" Action="None" />


### PR DESCRIPTION
Add FxCop Analyzer using the same ruleset in the main Jellyfin repository. Also includes fixes to all warnings produced by the analyzer in the existing code.