### PR TITLE
Use regex to perform case-insensitive string replacement

### DIFF
--- a/Emby.AutoOrganize/Core/NameUtils.cs
+++ b/Emby.AutoOrganize/Core/NameUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Model.Extensions;
@@ -75,10 +76,10 @@ namespace Emby.AutoOrganize.Core
             .Replace("-", " ")
             .Replace("'", " ")
             .Replace("[", " ")
-            .Replace("]", " ")
-            .Replace(" a ", String.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace(" the ", String.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace(" ", String.Empty);
+            .Replace("]", " ");
+            name = Regex.Replace(name, " a ", String.Empty, RegexOptions.IgnoreCase);
+            name = Regex.Replace(name, " the ", String.Empty, RegexOptions.IgnoreCase);
+            name = name.Replace(" ", String.Empty);
 
             return name.Trim();
         }


### PR DESCRIPTION
The previously used `Replace()` extension method was (wisely) removed from the Jellyfin library here: https://github.com/jellyfin/jellyfin/commit/fdbb32911835b5ed8e39f518ccc20b0a26bd8bab#diff-1304277a2e8d9ed5b54751a3f6d121acL30

This PR replaces the deleted extension method with an equivalent call to `Regex.Replace()`.

