### PR TITLE
Bump Version and make compatible with jellyfin 10.5

### DIFF
--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -297,7 +297,7 @@ namespace Emby.AutoOrganize.Core
             }
 
             // async outside of the lock for perfs
-            var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_logger, _fileSystem))
+            var refreshOptions = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
             {
                 SearchResult = result
             };

--- a/Emby.AutoOrganize/Emby.AutoOrganize.csproj
+++ b/Emby.AutoOrganize/Emby.AutoOrganize.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>5.0.0</AssemblyVersion>
-    <FileVersion>5.0.0</FileVersion>
+    <AssemblyVersion>6.0.0</AssemblyVersion>
+    <FileVersion>6.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/Emby.AutoOrganize/Emby.AutoOrganize.csproj
+++ b/Emby.AutoOrganize/Emby.AutoOrganize.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyVersion>6.0.0</AssemblyVersion>
     <FileVersion>6.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-autoorganize"
 guid: "70b7b43b-471b-4159-b4be-56750c795499"
-version: "5" # Please increment with each pull request
-jellyfin_version: "10.4.3" # The earliest binary-compatible version
+version: "6" # Please increment with each pull request
+jellyfin_version: "10.5.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Auto Organize"
 description: "Automatically organize your media"


### PR DESCRIPTION
- Update build to target `netstandard2.1`
- Fix build errors from updated NuGet packages
- Bump plugin version to `6.0.0`