### PR TITLE
Use Scoped Loggers

### DIFF
--- a/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/EpisodeFileOrganizer.cs
@@ -30,7 +30,7 @@ namespace Emby.AutoOrganize.Core
     {
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger _logger;
+        private readonly ILogger<EpisodeFileOrganizer> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
         private readonly IProviderManager _providerManager;
@@ -46,7 +46,7 @@ namespace Emby.AutoOrganize.Core
         public EpisodeFileOrganizer(
             IFileOrganizationService organizationService,
             IFileSystem fileSystem,
-            ILogger logger,
+            ILogger<EpisodeFileOrganizer> logger,
             ILibraryManager libraryManager,
             ILibraryMonitor libraryMonitor,
             IProviderManager providerManager)

--- a/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFileOrganizer.cs
@@ -27,7 +27,7 @@ namespace Emby.AutoOrganize.Core
     {
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger _logger;
+        private readonly ILogger<MovieFileOrganizer> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
         private readonly IProviderManager _providerManager;
@@ -40,7 +40,7 @@ namespace Emby.AutoOrganize.Core
         public MovieFileOrganizer(
             IFileOrganizationService organizationService,
             IFileSystem fileSystem,
-            ILogger logger,
+            ILogger<MovieFileOrganizer> logger,
             ILibraryManager libraryManager,
             ILibraryMonitor libraryMonitor,
             IProviderManager providerManager)

--- a/Emby.AutoOrganize/Core/MovieFolderOrganizer.cs
+++ b/Emby.AutoOrganize/Core/MovieFolderOrganizer.cs
@@ -21,7 +21,8 @@ namespace Emby.AutoOrganize.Core
     {
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger _logger;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<MovieFolderOrganizer> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
         private readonly IServerConfigurationManager _config;
@@ -33,7 +34,7 @@ namespace Emby.AutoOrganize.Core
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:Element parameters should be documented", Justification = "Parameter types/names are self-documenting")]
         public MovieFolderOrganizer(
             ILibraryManager libraryManager,
-            ILogger logger,
+            ILoggerFactory loggerFactory,
             IFileSystem fileSystem,
             ILibraryMonitor libraryMonitor,
             IFileOrganizationService organizationService,
@@ -41,7 +42,8 @@ namespace Emby.AutoOrganize.Core
             IProviderManager providerManager)
         {
             _libraryManager = libraryManager;
-            _logger = logger;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<MovieFolderOrganizer>();
             _fileSystem = fileSystem;
             _libraryMonitor = libraryMonitor;
             _organizationService = organizationService;
@@ -112,7 +114,13 @@ namespace Emby.AutoOrganize.Core
             {
                 var numComplete = 0;
 
-                var organizer = new MovieFileOrganizer(_organizationService, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
+                var organizer = new MovieFileOrganizer(
+                    _organizationService,
+                    _fileSystem,
+                    _loggerFactory.CreateLogger<MovieFileOrganizer>(),
+                    _libraryManager,
+                    _libraryMonitor, 
+                    _providerManager);
 
                 foreach (var file in eligibleFiles)
                 {

--- a/Emby.AutoOrganize/Core/OrganizerScheduledTask.cs
+++ b/Emby.AutoOrganize/Core/OrganizerScheduledTask.cs
@@ -20,7 +20,8 @@ namespace Emby.AutoOrganize.Core
     {
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger _logger;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<OrganizerScheduledTask> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IServerConfigurationManager _config;
         private readonly IProviderManager _providerManager;
@@ -29,11 +30,18 @@ namespace Emby.AutoOrganize.Core
         /// Initializes a new instance of the <see cref="OrganizerScheduledTask"/> class.
         /// </summary>
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:Element parameters should be documented", Justification = "Parameter types/names are self-documenting")]
-        public OrganizerScheduledTask(ILibraryMonitor libraryMonitor, ILibraryManager libraryManager, ILogger logger, IFileSystem fileSystem, IServerConfigurationManager config, IProviderManager providerManager)
+        public OrganizerScheduledTask(
+            ILibraryMonitor libraryMonitor,
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem,
+            IServerConfigurationManager config,
+            IProviderManager providerManager)
         {
             _libraryMonitor = libraryMonitor;
             _libraryManager = libraryManager;
-            _logger = logger;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<OrganizerScheduledTask>();
             _fileSystem = fileSystem;
             _config = config;
             _providerManager = providerManager;
@@ -76,7 +84,14 @@ namespace Emby.AutoOrganize.Core
                 queueTv = options.TvOptions.QueueLibraryScan;
                 var fileOrganizationService = PluginEntryPoint.Current.FileOrganizationService;
 
-                await new TvFolderOrganizer(_libraryManager, _logger, _fileSystem, _libraryMonitor, fileOrganizationService, _config, _providerManager)
+                await new TvFolderOrganizer(
+                    _libraryManager,
+                    _loggerFactory,
+                    _fileSystem,
+                    _libraryMonitor,
+                    fileOrganizationService,
+                    _config,
+                    _providerManager)
                     .Organize(options.TvOptions, progress, cancellationToken).ConfigureAwait(false);
             }
 
@@ -85,7 +100,7 @@ namespace Emby.AutoOrganize.Core
                 queueMovie = options.MovieOptions.QueueLibraryScan;
                 var fileOrganizationService = PluginEntryPoint.Current.FileOrganizationService;
 
-                await new MovieFolderOrganizer(_libraryManager, _logger, _fileSystem, _libraryMonitor, fileOrganizationService, _config, _providerManager)
+                await new MovieFolderOrganizer(_libraryManager, _loggerFactory, _fileSystem, _libraryMonitor, fileOrganizationService, _config, _providerManager)
                     .Organize(options.MovieOptions, progress, cancellationToken).ConfigureAwait(false);
             }
 

--- a/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
+++ b/Emby.AutoOrganize/Core/TvFolderOrganizer.cs
@@ -21,7 +21,8 @@ namespace Emby.AutoOrganize.Core
     {
         private readonly ILibraryMonitor _libraryMonitor;
         private readonly ILibraryManager _libraryManager;
-        private readonly ILogger _logger;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<TvFolderOrganizer> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IFileOrganizationService _organizationService;
         private readonly IServerConfigurationManager _config;
@@ -31,10 +32,18 @@ namespace Emby.AutoOrganize.Core
         /// Initializes a new instance of the <see cref="TvFolderOrganizer"/> class.
         /// </summary>
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1611:Element parameters should be documented", Justification = "Parameter types/names are self-documenting")]
-        public TvFolderOrganizer(ILibraryManager libraryManager, ILogger logger, IFileSystem fileSystem, ILibraryMonitor libraryMonitor, IFileOrganizationService organizationService, IServerConfigurationManager config, IProviderManager providerManager)
+        public TvFolderOrganizer(
+            ILibraryManager libraryManager,
+            ILoggerFactory loggerFactory,
+            IFileSystem fileSystem,
+            ILibraryMonitor libraryMonitor,
+            IFileOrganizationService organizationService,
+            IServerConfigurationManager config,
+            IProviderManager providerManager)
         {
             _libraryManager = libraryManager;
-            _logger = logger;
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<TvFolderOrganizer>();
             _fileSystem = fileSystem;
             _libraryMonitor = libraryMonitor;
             _organizationService = organizationService;
@@ -105,7 +114,13 @@ namespace Emby.AutoOrganize.Core
             {
                 var numComplete = 0;
 
-                var organizer = new EpisodeFileOrganizer(_organizationService, _fileSystem, _logger, _libraryManager, _libraryMonitor, _providerManager);
+                var organizer = new EpisodeFileOrganizer(
+                    _organizationService,
+                    _fileSystem,
+                    _loggerFactory.CreateLogger<EpisodeFileOrganizer>(),
+                    _libraryManager,
+                    _libraryMonitor,
+                    _providerManager);
 
                 foreach (var file in eligibleFiles)
                 {

--- a/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
+++ b/Emby.AutoOrganize/Data/SqliteFileOrganizationRepository.cs
@@ -30,7 +30,7 @@ namespace Emby.AutoOrganize.Data
         /// <param name="appPaths">The server application paths.</param>
         /// <param name="jsonSerializer">A JSON serializer.</param>
         public SqliteFileOrganizationRepository(
-            ILogger logger,
+            ILogger<SqliteFileOrganizationRepository> logger,
             IServerApplicationPaths appPaths,
             IJsonSerializer jsonSerializer)
             : base(logger)

--- a/Emby.AutoOrganize/Emby.AutoOrganize.csproj
+++ b/Emby.AutoOrganize/Emby.AutoOrganize.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyVersion>6.0.0</AssemblyVersion>
-    <FileVersion>6.0.0</FileVersion>
+    <AssemblyVersion>7.0.0</AssemblyVersion>
+    <FileVersion>7.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-autoorganize"
 guid: "70b7b43b-471b-4159-b4be-56750c795499"
-version: "6" # Please increment with each pull request
+version: "7" # Please increment with each pull request
 jellyfin_version: "10.5.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Auto Organize"


### PR DESCRIPTION
Replace all instances of ILogger with ILogger<T>, which will provide a class context to all log messages.

This also fixes the plugin, which has been broken by https://github.com/jellyfin/jellyfin/pull/3098